### PR TITLE
add file load support for Headers, add new load subcommand

### DIFF
--- a/cmd/load.go
+++ b/cmd/load.go
@@ -1,0 +1,79 @@
+/*
+Copyright © 2019 NAME HERE <EMAIL ADDRESS>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"strconv"
+
+	"github.com/spf13/cobra"
+)
+
+type requestJSON []struct {
+	Description string `json:"description"`
+	URL         string `json:"url"`
+	Method      string `json:"method"`
+	Amount      int    `json:"amount"`
+	Body        string `json:"body"`
+	Headers     string `json:"headers"`
+	Bfile       string `json:"bfile"`
+	Hfile       string `json:"hfile"`
+	Output      string `json:"output"`
+}
+
+// loadCmd represents the load command
+var loadCmd = &cobra.Command{
+	Use:   "load",
+	Short: "Execute request jobs stored in a JSON file.",
+	Run: func(cmd *cobra.Command, args []string) {
+		filename, _ := cmd.Flags().GetString("file")
+
+		bytes, err := ioutil.ReadFile(filename)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%s", err)
+			os.Exit(1)
+		}
+		var requests requestJSON
+		err = json.Unmarshal(bytes, &requests)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%s", err)
+			os.Exit(1)
+		}
+
+		for _, req := range requests {
+			reqArgs := []string{"request", "-u", req.URL, "-m", req.Method, "-n", strconv.Itoa(req.Amount),
+				"-b", req.Body, "-H", req.Headers, "--bfile", req.Bfile, "--hfile", req.Hfile, "-o", req.Output}
+			fmt.Println(reqArgs)
+
+			out, err := exec.Command("netmeg", reqArgs...).CombinedOutput()
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error running request '%s': %s\n%s\n", req.Description, err, out)
+				continue
+			}
+			fmt.Printf("%s\n", out)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(loadCmd)
+
+	loadCmd.Flags().StringP("file", "f", "", "JSON file containing requests")
+}

--- a/cmd/request.go
+++ b/cmd/request.go
@@ -50,17 +50,22 @@ var requestCmd = &cobra.Command{
 		url, _ := cmd.Flags().GetString("url")
 		amount, _ := cmd.Flags().GetInt("amount")
 		body, _ := cmd.Flags().GetString("body")
+		headers, _ := cmd.Flags().GetString("headers")
 		bodyFile, _ := cmd.Flags().GetString("bfile")
+		headerFile, _ := cmd.Flags().GetString("hfile")
 
 		if bodyFile != "" {
 			body = parseFile(bodyFile)
 		}
 
-		headers, _ := cmd.Flags().GetString("headers")
+		if headerFile != "" {
+			headers = parseFile(headerFile)
+		}
 		headersMap := make(map[string]string)
 		if headers != "" {
 			headersMap = prepareHeaders(headers)
 		}
+		fmt.Println(headersMap)
 
 		filename, _ := cmd.Flags().GetString("output")
 		if filename == "" {
@@ -121,7 +126,8 @@ func init() {
 	requestCmd.Flags().StringP("output", "o", "", "Path to file for results")
 	requestCmd.Flags().StringP("headers", "H", "", "Header list formated as {key}:{value}, separated by commas")
 	requestCmd.Flags().StringP("body", "b", "", "Request body")
-	requestCmd.Flags().String("bfile", "", "File containing Request body (overrides -body and -b flags)")
+	requestCmd.Flags().String("bfile", "", "File containing Request body (overrides --body and -b flags)")
+	requestCmd.Flags().String("hfile", "", "File containing Headers (overrides --headers and -H flags)")
 }
 
 // Submit request and send http.Response to channel 'c'.

--- a/cmd/request.go
+++ b/cmd/request.go
@@ -65,7 +65,6 @@ var requestCmd = &cobra.Command{
 		if headers != "" {
 			headersMap = prepareHeaders(headers)
 		}
-		fmt.Println(headersMap)
 
 		filename, _ := cmd.Flags().GetString("output")
 		if filename == "" {


### PR DESCRIPTION
- added new flag '-hfile' than can be used to load Headers from a file, rather than using the command line;
`netmeg request -u https://jsonplaceholder.typicode.com/posts -m post -b "{\"title\": \"This is a title.\"}" --hfile headers.txt`
where headers.txt is a file in the current working directory that contains the text
`Content-Type:application/json, Test: 123` (one line)

- added new sub command 'load';
`netmeg load -f schedule.json`
where schedule.json is a JSON array containing multiple request JSON objects.
```json
[
    {
        "description": "Simple Google GET x 5",
        "url": "https://google.com",
        "method": "get",
        "amount": 5,
        "body": "",
        "headers": "",
        "bfile": "",
        "hfile": "",
        "output": ""
    },
    {
        "description": "JSON Placeholder test site POST x 10",
        "url": "https://jsonplaceholder.typicode.com/posts",
        "method": "POST",
        "amount": 10,
        "body": "{\"title\": \"This is a title.\"}",
        "headers": "Content-Type:application/json",
        "bfile": "",
        "hfile": "",
        "output": "post-response.log"
    }
]
```
Each request JSON object will be executed sequentially** by the `netmeg request` sub command.  The JSON fields directly correspond with the netmeg request flags, and follow the same rules.

**Note that each request will still run 'amount' number of times asynchronously.