### PR TITLE
add {timestamp} macro for filename and --mode flag for output mode (console, file, or both)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.log
+.vscode/

--- a/cmd/load.go
+++ b/cmd/load.go
@@ -36,6 +36,7 @@ type requestJSON []struct {
 	Bfile       string `json:"bfile"`
 	Hfile       string `json:"hfile"`
 	Output      string `json:"output"`
+	Mode        string `json:"mode"`
 }
 
 // loadCmd represents the load command
@@ -59,7 +60,7 @@ var loadCmd = &cobra.Command{
 
 		for _, req := range requests {
 			reqArgs := []string{"request", "-u", req.URL, "-m", req.Method, "-n", strconv.Itoa(req.Amount),
-				"-b", req.Body, "-H", req.Headers, "--bfile", req.Bfile, "--hfile", req.Hfile, "-o", req.Output}
+				"-b", req.Body, "-H", req.Headers, "--bfile", req.Bfile, "--hfile", req.Hfile, "-o", req.Output, "--mode", req.Mode}
 			fmt.Println(reqArgs)
 
 			out, err := exec.Command("netmeg", reqArgs...).CombinedOutput()


### PR DESCRIPTION
- You can now specify the **{timestamp}** macro in a filename (using both the CLI and the pre-made request JSON file).  For example;
`netmeg request -u https://google.com -o ./get-request-{timestamp}.log`
will write the request results to the file get-request-20191129135838.log if the request processed on 11/29/2019 at 1:58:38 PM (your system's current timezone).

- You can now choose between writing the request results to the console, to a file, or both using the --mode flag;
`netmeg request -u https://google.com --mode console`
will write the request response directly to the console.  "console" is the default mode.
`netmeg request -u https://google.com --mode both`
will write the request response to both the console as well as a file.  Since no file was specified using the --output (-o) flag, the file name will be the default **results-{timestamp}.log**.
