### PR TITLE
add go-release Github Actions workflow

### DIFF
--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -65,3 +65,20 @@ jobs:
         asset_path: ./netmeg-release-${{ steps.get_version.outputs.version }}.tar.gz
         asset_name: netmeg-release-${{ steps.get_version.outputs.version }}.tar.gz
         asset_content_type: application/gzip
+
+    - name: Build (Windows)
+      run: |
+        GOOS=windows go get -u github.com/spf13/cobra
+        env GOOS=windows GOARCH=amd64 go build -v .
+        zip netmeg-release-${{ steps.get_version.outputs.version }}.zip ./netmeg.exe
+    
+    - name: Upload Release Asset (Windows)
+      id: upload-release-asset-windows
+      uses: actions/upload-release-asset@v1.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+        asset_path: ./netmeg-release-${{ steps.get_version.outputs.version }}.zip
+        asset_name: netmeg-release-${{ steps.get_version.outputs.version }}.zip
+        asset_content_type: application/zip

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -1,0 +1,33 @@
+name: go-release
+on: [push]
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Set up Go 1.13
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.13
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v1
+      
+    - name: Get the version
+      id: get_version
+      run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+      shell: bash
+
+    #- name: Get dependencies
+    #  run: |
+    #    go get -v -t -d ./...
+    #    if [ -f Gopkg.toml ]; then
+    #        curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+    #        dep ensure
+    #    fi
+
+    #- name: Build
+    #  run: go build -v .

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -50,5 +50,18 @@ jobs:
         draft: false
         prerelease: true
 
-    #- name: Build
-    #  run: go build -v .
+    - name: Build (Linux)
+      run: |
+        go build -v .
+        tar -czvf netmeg-release-${{ steps.get_version.outputs.version }}.tar.gz ./netmeg
+    
+    - name: Upload Release Asset (Linux)
+      id: upload-release-asset-linux
+      uses: actions/upload-release-asset@v1.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+        asset_path: ./netmeg-release-${{ steps.get_version.outputs.version }}.tar.gz
+        asset_name: netmeg-release-${{ steps.get_version.outputs.version }}.tar.gz
+        asset_content_type: application/gzip

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -23,10 +23,6 @@ jobs:
       
     - name: Print version
       shell: bash
-      run: echo ${{ github.ref/refs\/tags\// }}
-      
-    - name: Print version 2
-      shell: bash
       run: echo ${{ steps.get_version.outputs.version }}
 
     #- name: Get dependencies

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -3,6 +3,7 @@ on:
   push:
     tags:
       - 'v*'
+    branches: [master]
 jobs:
 
   build:

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -20,6 +20,14 @@ jobs:
       id: get_version
       run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
       shell: bash
+      
+    - name: Print version
+      shell: bash
+      run: echo ${{ github.ref/refs\/tags\// }}
+      
+    - name: Print version 2
+      shell: bash
+      run: echo ${{ steps.get_version.outputs.version }}
 
     #- name: Get dependencies
     #  run: |

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -1,9 +1,12 @@
 name: go-release
-on: [push]
+on:
+  push:
+    tags:
+      - 'v*'
 jobs:
 
   build:
-    name: Build
+    name: Create release
     runs-on: ubuntu-latest
     steps:
 
@@ -16,6 +19,15 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v1
       
+    - name: Get dependencies
+      shell: bash
+      run: |
+        go get -v -t -d ./...
+        if [ -f Gopkg.toml ]; then
+            curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+            dep ensure
+        fi
+      
     - name: Get the version
       id: get_version
       run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
@@ -24,14 +36,19 @@ jobs:
     - name: Print version
       shell: bash
       run: echo ${{ steps.get_version.outputs.version }}
-
-    #- name: Get dependencies
-    #  run: |
-    #    go get -v -t -d ./...
-    #    if [ -f Gopkg.toml ]; then
-    #        curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-    #        dep ensure
-    #    fi
+      
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+      with:
+        tag_name: ${{ steps.get_version.outputs.version }}
+        release_name: Release ${{ steps.get_version.outputs.version }}
+        body: |
+          Changes in this Release
+        draft: false
+        prerelease: true
 
     #- name: Build
     #  run: go build -v .


### PR DESCRIPTION
go-release will run when a new release (tagged with vx.y.z) is ready from the master branch. 